### PR TITLE
Switch to box, Add Walls/Config/Tree and turn off god attack

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,13 @@
+scope = global
+
+[game]
+max_survivors = 1
+
+[map]
+width = 60
+height = 60
+
+[map.tree]
+lower_size = 3
+upper_size = 5
+num = 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,6 +342,11 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
         "ipaddr.js": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "dependencies": {
                 "express": "^4.16.4",
                 "gl-matrix": "^3.0.0",
+                "ini": "^1.3.5",
                 "socket.io": "^2.2.0"
         }
 }

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -177,7 +177,11 @@ socket.on('game_status', function (msg) {
             glMatrix.mat4.fromTranslation(translation, position);
             const transformation = glMatrix.mat4.create();
             glMatrix.mat4.multiply(transformation, translation, rotation);
-            glMatrix.mat4.multiply(objects[name].t, transformation, transform_ref[objects[name].m]);
+            let t = glMatrix.mat4.clone(transform_ref[objects[name].m]);
+            if (objects[name].m === 'tree') {
+                t = glMatrix.mat4.fromScaling(t, [obj.size, obj.size, obj.size]);
+            } 
+            glMatrix.mat4.multiply(objects[name].t, transformation, t);
         }
     });
 

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -216,12 +216,13 @@ class Bullet {
 }
 
 class Tree {
-    constructor(treeId) {
+    constructor(treeId, size) {
         this.name = 'Tree ' + treeId;
         this.radius = 0;    // only to suppress error when assigning position from physics engine
         this.position = [20, 0, -20];
         this.direction = [0, 0, -1];
         this.model = 'tree';
+        this.size = size;
     }
 }
 
@@ -254,12 +255,8 @@ class GameInstance {
             'HealerCount': 0,
             'BuilderCount': 0
         }
-
-        const tree = new Tree(this.treeId++);
-        this.toSend.push(tree.name);
-        this.insertObjListAndMap(tree);
-        this.physicsEngine.addTree(tree.name);
         this.loadConfig(config);
+        this.generateEnvironment();
     }
 
     loadConfig(config) {
@@ -267,6 +264,18 @@ class GameInstance {
         this.treeLowerSize = parseInt(config.map.tree.lower_size);
         this.treeUpperSize = parseInt(config.map.tree.upper_size);
         this.treeNum = config.map.tree.num;
+    }
+
+    generateEnvironment() {
+        // Generate Tree
+        for (let i = 0; i < this.treeNum; i++) {
+            let diff = this.treeUpperSize - this.treeLowerSize + 1;
+            const size = Math.floor(Math.random() * diff) + this.treeLowerSize;
+            const tree = new Tree(this.treeId++, size);
+            this.toSend.push(tree.name);
+            this.insertObjListAndMap(tree);
+            this.physicsEngine.addTree(tree.name, true, tree.size);
+        }
     }
 
     insertObjListAndMap(obj) {

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -39,6 +39,7 @@ class God {
         this.jumpSpeed = 10;
         this.model = 'player';
         this.radius = 2;
+        this.canAttack = false; // Need to be switched on at endgame
         this.skills = {
             0: {
                 'name': 'Slime',
@@ -407,6 +408,7 @@ class GameInstance {
      */
     shoot(name) {
         const initiator = this.objects[name];
+        if (name === 'God' && !initiator.canAttack) return;
         const bullet = new Bullet(initiator.position, initiator.direction, this.bulletId++);
         this.toSend.push(bullet.name);
 
@@ -416,6 +418,7 @@ class GameInstance {
 
     melee(name) {
         const initiator = this.objects[name];
+        if (name === 'God' && !initiator.canAttack) return;
         const meleeId = "Melee " + (this.meleeId++);
         this.physicsEngine.melee(name, initiator.direction, meleeId, initiator.status.STATUS_damage);
     }

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -226,8 +226,7 @@ class Tree {
 }
 
 class GameInstance {
-    constructor(max_survivors = 3, physicsEngine) {
-        this.max_survivors = max_survivors;
+    constructor(config, physicsEngine) {
         this.survivorCount = 0;
         this.slimeCount = 0;
         this.treeId = 0;
@@ -260,6 +259,14 @@ class GameInstance {
         this.toSend.push(tree.name);
         this.insertObjListAndMap(tree);
         this.physicsEngine.addTree(tree.name);
+        this.loadConfig(config);
+    }
+
+    loadConfig(config) {
+        this.max_survivors = config.game.max_survivors;
+        this.treeLowerSize = parseInt(config.map.tree.lower_size);
+        this.treeUpperSize = parseInt(config.map.tree.upper_size);
+        this.treeNum = config.map.tree.num;
     }
 
     insertObjListAndMap(obj) {

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -196,6 +196,16 @@ class PhysicsEngine {
         this.obj[name] = treeBody;
     }
 
+    /**
+     * This function would immunity of god
+     */
+    switchGodImmunity() {
+        const god = this.obj['God'];
+        const isImmune = god.body.collisionFilterMask === BOUNDARY;
+        god.body.collisionFilterMask = isImmune ? 
+            (SURVIVORS | ENVIRONMENT | BOUNDARY | BULLET | MELEE) : BOUNDARY;
+    }
+
     updateVelocity(name, direction, speed) {
         this.obj[name].velocity.x = direction[0] * speed;
         this.obj[name].velocity.z = direction[2] * speed;

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -111,9 +111,10 @@ class PhysicsEngine {
         groundBody.role = 'ground';
     }
 
-    addTree(name, radius = 1, position = { x: 20, y: 0, z: -20 }) {
+    addTree(name, radius = 0.5, position = { x: 20, y: 0, z: -20 }) {
         // tree should be static 
-        const treeShape = new CANNON.Cylinder(radius, radius, radius * 2, 10);
+        const treeShape = new CANNON.Box(new CANNON.Vec3(radius, 20 * radius, radius));
+        // const treeShape = new CANNON.Cylinder(radius, radius, radius * 10, 10);
         const treeBody = new CANNON.Body({
             mass: 0,
             shape: treeShape

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -1,7 +1,7 @@
 const CANNON = require('../lib/cannon.min.js');
 const glMatrix = require('gl-Matrix');
 class PhysicsEngine {
-    constructor() {
+    constructor(mapWidth, mapHeight) {
         this.obj = {};
 
         // Create the world
@@ -11,8 +11,10 @@ class PhysicsEngine {
         this.world.solver.iterations = 10;
 
         this.defineMaterial();
-
         this.addGroundPlane(this.groundMaterial);
+        this.mapWidth = mapWidth;
+        this.mapHeight = mapHeight;
+        this.addMapBoundary(mapWidth, mapHeight);
 
         // Store all hits in current step
         this.hits = [];
@@ -68,7 +70,28 @@ class PhysicsEngine {
         this.ground = groundBody;
         groundBody.role = 'ground';
     }
-    //----------------------------------------- End of World Setup --------------------------------
+
+    addMapBoundary(mapWidth, mapHeight) {
+        console.log("Map width:", mapWidth, "height:", mapHeight);
+        const wallThickness = 0.01;
+        // Add four boxes as walls around the map
+        const northBoundWallshape = new CANNON.Box(new CANNON.Vec3(mapWidth/2, 500, wallThickness));
+        const northWall = new CANNON.Body({ mass: 0, shape: northBoundWallshape });
+        northWall.position.set(0, 500, -mapHeight/2 - wallThickness);
+        this.world.add(northWall); 
+        const southWall = new CANNON.Body({ mass: 0, shape: northBoundWallshape });
+        southWall.position.set(0, 500, mapHeight/2 + wallThickness);
+        this.world.add(southWall); 
+
+        const eastBoundWallshape = new CANNON.Box(new CANNON.Vec3(wallThickness, 500, mapHeight/2));
+        const eastWall = new CANNON.Body({ mass: 0, shape: eastBoundWallshape });
+        eastWall.position.set(mapWidth/2 + wallThickness, 500, 0);
+        this.world.add(eastWall);     
+        const westWall = new CANNON.Body({ mass: 0, shape: eastBoundWallshape });
+        westWall.position.set(-mapWidth/2 - wallThickness, 500, 0);
+        this.world.add(westWall); 
+    }
+    //-------------------------------------- End of World Setup --------------------------------
 
     
     addPlayer(name, mass = 20, radius, position = { x: 0, y: 0, z: 0 }, maxJump, isGod = false) {

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -181,9 +181,15 @@ class PhysicsEngine {
 
     }
 
-    addTree(name, radius = 0.5, position = { x: 20, y: 0, z: -20 }) {
+    addTree(name, random, size, radius = 0.5, position = { x: 20, y: 0, z: -20 }) {
+        if (random) {
+            // randomly generate tree position
+            position.x = Math.floor(Math.random() * (this.mapWidth - Math.ceil(radius)) + Math.ceil(radius)) - this.mapWidth/2;
+            position.y = 0;
+            position.z = Math.floor(Math.random() * (this.mapHeight - Math.ceil(radius)) + Math.ceil(radius)) - this.mapHeight/2;
+        }
         // tree should be static 
-        const treeShape = new CANNON.Box(new CANNON.Vec3(radius, 20 * radius, radius));
+        const treeShape = new CANNON.Box(new CANNON.Vec3(radius, size * 4 * radius, radius));
         // const treeShape = new CANNON.Cylinder(radius, radius, radius * 10, 10);
         const treeBody = new CANNON.Body({
             mass: 0,

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -30,6 +30,7 @@ class PhysicsEngine {
         this.slimeExplosion = [];
     }
 
+    //----------------------------------------- World Setup --------------------------------
     defineMaterial() {
         this.groundMaterial = new CANNON.Material("groundMaterial");
         // Adjust constraint equation parameters for ground/ground contact
@@ -57,6 +58,19 @@ class PhysicsEngine {
         this.world.addContactMaterial(slime_player_cm);
     }
 
+    addGroundPlane(material) {
+        // Make a statis ground plane with mass 0
+        const groundShape = new CANNON.Plane();
+        const groundBody = new CANNON.Body({ mass: 0, shape: groundShape, material: material });
+        groundBody.quaternion.setFromAxisAngle(new CANNON.Vec3(1, 0, 0), -Math.PI / 2);
+        groundBody.computeAABB();
+        this.world.add(groundBody);
+        this.ground = groundBody;
+        groundBody.role = 'ground';
+    }
+    //----------------------------------------- End of World Setup --------------------------------
+
+    
     addPlayer(name, mass = 20, radius, position = { x: 0, y: 0, z: 0 }, maxJump, isGod = false) {
         // const shape = new CANNON.Sphere(radius);
         const shape = new CANNON.Box(new CANNON.Vec3(radius, radius, radius));
@@ -112,17 +126,6 @@ class PhysicsEngine {
             })
         }
 
-    }
-
-    addGroundPlane(material) {
-        // Make a statis ground plane with mass 0
-        const groundShape = new CANNON.Plane();
-        const groundBody = new CANNON.Body({ mass: 0, shape: groundShape, material: material });
-        groundBody.quaternion.setFromAxisAngle(new CANNON.Vec3(1, 0, 0), -Math.PI / 2);
-        groundBody.computeAABB();
-        this.world.add(groundBody);
-        this.ground = groundBody;
-        groundBody.role = 'ground';
     }
 
     addTree(name, radius = 0.5, position = { x: 20, y: 0, z: -20 }) {

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -282,8 +282,8 @@ class PhysicsEngine {
 
         const engine = this;
         attackBody.addEventListener("collide", function (e) {
-            console.log("Melee hit:", name, "->", e.body.name);
-            if (e.body.name != name) {
+            if (e.body.name != name && e.body.role != engine.obj[name].role) {
+                console.log("Melee hit:", name, "->", e.body.name);
                 if (e.body.role === 'enemy' || e.body.role === 'survivor') {
                     attackBody.to = e.body.name; // TODO: Change to array?
                     engine.hits.push(meleeId);
@@ -346,7 +346,7 @@ class PhysicsEngine {
         const engine = this;
         bulletBody.addEventListener("collide", function(e) {
             console.log("Bullet hit:", name, "->", e.body.name);
-            if (e.body.name != name) {
+            if (e.body.name != name && e.body.role != engine.obj[name].role) {
                 if (e.body.role === 'enemy') {
                     bulletBody.to = e.body.name; // TODO: Change to array?
                 } else if (e.body.role === 'survivor') {

--- a/public/js/physics.js
+++ b/public/js/physics.js
@@ -42,15 +42,15 @@ class PhysicsEngine {
     }
 
     addPlayer(name, mass = 20, radius, position = { x: 0, y: 0, z: 0 }, maxJump, isGod = false) {
-        // const ballShape = new CANNON.Sphere(radius);
-        const boxShape = new CANNON.Box(new CANNON.Vec3(radius, radius, radius));
+        // const shape = new CANNON.Sphere(radius);
+        const shape = new CANNON.Box(new CANNON.Vec3(radius, radius, radius));
         // Kinematic Box
         // Does only collide with dynamic bodies, but does not respond to any force.
         // Its movement can be controlled by setting its velocity.
         const mat = new CANNON.Material();
         const playerBody = new CANNON.Body({
             mass: mass,
-            shape: boxShape,
+            shape: shape,
             linearDamping: 0.5,
             material: mat,
             // type: CANNON.Body.KINEMATIC
@@ -74,12 +74,17 @@ class PhysicsEngine {
     }
 
     addSlime(name, mass = 5, radius, position = { x: 0, y: 0, z: 0 }, speed = 3, attackMode) {
-        const ballShape = new CANNON.Sphere(radius);
+        // const shape = new CANNON.Sphere(radius);
+        const shape = new CANNON.Box(new CANNON.Vec3(radius, radius, radius));
+        const mat = new CANNON.Material();
         const slimeBody = new CANNON.Body({
             mass: mass,
-            shape: ballShape,
+            shape: shape,
             linearDamping: 0.9,
+            material: mat
         });
+        const mat_ground = new CANNON.ContactMaterial(this.groundMaterial, mat, { friction: 0, restitution: 0.01 });
+        this.world.addContactMaterial(mat_ground);
         slimeBody.position.set(position.x, position.y + radius, position.z);
         slimeBody.jumps = 0;
         slimeBody.role = 'enemy';
@@ -232,9 +237,12 @@ class PhysicsEngine {
         bulletBody.velocity.set( direction[0] * shootingSpeed,
                                  direction[1] * shootingSpeed,
                                  direction[2] * shootingSpeed );
-        const x = initiator.position.x + direction[0] * (initiator.shapes[0].radius+ballShape.radius);
+        // const x = initiator.position.x + direction[0] * (initiator.shapes[0].radius+ballShape.radius);
+        // const y = initiator.position.y + direction[1] * (ballShape.radius) + 1.5;
+        // const z = initiator.position.z + direction[2] * (initiator.shapes[0].radius+ballShape.radius);
+        const x = initiator.position.x + direction[0] * (1.414 * initiator.shapes[0].halfExtents.x + ballShape.radius);
         const y = initiator.position.y + direction[1] * (ballShape.radius) + 1.5;
-        const z = initiator.position.z + direction[2] * (initiator.shapes[0].radius+ballShape.radius);
+        const z = initiator.position.z + direction[2] * (1.414 * initiator.shapes[0].halfExtents.z + ballShape.radius);
         bulletBody.position.set(x, y, z); 
         this.world.add(bulletBody);
 

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -16,9 +16,9 @@ function stringifyReplacer(key, value) {
         return arr
     }
 
-    if (key.startsWith('Tree')) {
-        return undefined;
-    }
+    // if (key.startsWith('Tree')) {
+    //     return undefined;
+    // }
 
     return value
 }

--- a/server.js
+++ b/server.js
@@ -6,6 +6,9 @@ const io = require('socket.io')(http, {
     pingTimeout: 3000,
 });
 const path = require('path');
+const fs = require('fs');
+const ini = require('ini');
+const config = ini.parse(fs.readFileSync('./config.ini', 'utf-8'))
 const game = require('./public/js/game.js');
 const physics = require('./public/js/physics.js');
 const Utils = require('./public/js/utils.js');
@@ -17,9 +20,8 @@ app.get('/', function (req, res) {
 });
 
 // TODO: read from config
-const max_survivors = 1;
 const physicsEngine = new physics();
-const gameInstance = new game(max_survivors, physicsEngine);
+const gameInstance = new game(config, physicsEngine);
 
 const inputs = [];
 const movementEvents = {};

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ app.get('/', function (req, res) {
 });
 
 // TODO: read from config
-const physicsEngine = new physics();
+const physicsEngine = new physics(config.map.width, config.map.height);
 const gameInstance = new game(config, physicsEngine);
 
 const inputs = [];


### PR DESCRIPTION
1. Boxes instead of spheres are used to represent body (resolves #16)
2. Fours walls are added
3. Now max_survivors/map size/tree numbers and sizes settings are loaded from config.ini
4. CollisionFilter is used to resolve #17. Survivors would still collide with other survivors and monsters (MAY NEED FIX)
5. God bullet/melee attack is turned off
 
Note: I didn't change the quarternion of the box body for now. The shape orientation remains (0, 0, 0, 1) after my attempt. Need another issue to work on it (#26).